### PR TITLE
add fiat amount and currency to transaction log

### DIFF
--- a/src/db/entities/ExternalTransactionLog.ts
+++ b/src/db/entities/ExternalTransactionLog.ts
@@ -14,4 +14,10 @@ export class ExternalTransactionLog extends ExternalTransactionBase {
 
   @Column({ type: 'decimal', nullable: true })
   amount: string;
+
+  @Column({ type: 'decimal', nullable: true })
+  fiat_amount: string;
+
+  @Column({ nullable: true })
+  fiat_currency: string;
 }

--- a/src/db/migrations/1638433973999-FiatCurrencyLog.ts
+++ b/src/db/migrations/1638433973999-FiatCurrencyLog.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class FiatCurrencyLog1638433973999 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "external_transaction_log"
+        ADD COLUMN fiat_currency varchar(10),
+        ADD COLUMN fiat_amount numeric;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "external_transaction_log"
+      DROP COLUMN fiat_currency,
+      DROP COLUMN fiat_amount;
+    `);
+  }
+}

--- a/src/lib/models/external_transaction_log.ts
+++ b/src/lib/models/external_transaction_log.ts
@@ -15,4 +15,6 @@ export interface ExternalTransactionLog {
   sender?: string;
   receiver?: string;
   amount?: string;
+  fiat_currency?: string;
+  fiat_amount?: string;
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature to extend transaction log model
- **What is the current behavior?** (You can also link to an open issue here)
N/A
- **What is the new behavior (if this is a feature change)?**
ExternalTransactionLog model now has optional `fiat_amount` and `fiat_currency`. An appropriate table migration is also present.
