### PR TITLE
add fee property on ExternalTransactionLog

### DIFF
--- a/src/db/entities/ExternalTransactionLog.ts
+++ b/src/db/entities/ExternalTransactionLog.ts
@@ -16,6 +16,9 @@ export class ExternalTransactionLog extends ExternalTransactionBase {
   amount: string;
 
   @Column({ type: 'decimal', nullable: true })
+  fee: string;
+
+  @Column({ type: 'decimal', nullable: true })
   fiat_amount: string;
 
   @Column({ nullable: true })

--- a/src/db/migrations/1639058103129-AddFeeToTransactionLog.ts
+++ b/src/db/migrations/1639058103129-AddFeeToTransactionLog.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFeeToTransactionLog1639058103129 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+          ALTER TABLE "external_transaction_log"
+            ADD COLUMN fee numeric;
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+          ALTER TABLE "external_transaction_log"
+          DROP COLUMN fee;
+        `);
+  }
+}

--- a/src/lib/models/external_transaction_log.ts
+++ b/src/lib/models/external_transaction_log.ts
@@ -15,6 +15,7 @@ export interface ExternalTransactionLog {
   sender?: string;
   receiver?: string;
   amount?: string;
+  fee?: string;
   fiat_currency?: string;
   fiat_amount?: string;
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Extends ExternalTransactionLog with the `fee` property.

- **What is the current behavior?** (You can also link to an open issue here)
N/A

- **What is the new behavior (if this is a feature change)?**
ExternalTransactionLog now has an optional `fee` property.

- **Other information**:
Includes a database migration, and updates to the TypeORM entity and interface.